### PR TITLE
Proc SQL parsing in sasdoc

### DIFF
--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -355,8 +355,9 @@ class procedure:
     """
     outputs = attr.ib()
     inputs = attr.ib()
-    type = attr.ib()
+    type = attr.ib(default='sql')
     
+
 @attr.s 
 class libname:
     """
@@ -646,6 +647,21 @@ proc = ps.seq(
     _h3 = ps.regex(r'.*?(?=run|quit)', flags=reFlags),
     _run = (run|qt) + opspc + col
 ).combine_dict(procedure)
+
+# crtetbl: Parser for create table sql statement
+
+crtetbl = ps.seq(
+    outputs = ps.regex(r'create table', flags=reFlags) + opspc >> dataObj <<  opspc + ps.regex(r'as'),
+    inputs = (ps.regex(r'.*?from', flags=reFlags) + spc + opspc >> dataObj).many(),
+    _h = ps.regex(r'.*?(?=;)', flags=reFlags) + col
+).combine_dict(procedure)
+
+# sql: Abstracted proc sql statement, three primary components:
+#   - output: Output of the create table statement
+#   - inputs Any dataset referenced next to a from statement
+
+sql = ps.regex(r'proc sql', flags=reFlags) + opspc + col + opspc >> crtetbl.many() << ps.regex(r'.*?quit', flags=reFlags) + opspc + col
+
 
 # lbnm: Abstracted libname statement, three components:
 #   - library: name of library reference in code 

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -5,8 +5,6 @@ import attr
 import re
 import parsy as ps
 
-from itertools import chain
-
 log = logging.getLogger(__name__) 
 
 def flatten_list(aList):

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -9,14 +9,28 @@ from itertools import chain
 
 log = logging.getLogger(__name__) 
 
-def flatten(aList):
-    f = []
-    for obj in aList:
-        if not isinstance(obj, list):
-            f.append(obj)
+def flatten_list(aList):
+    '''
+    Recursively dig through a list flattening all none list
+    objects into a single list. 
+
+    Parameters
+    ----------
+    aList : list 
+        List of nested lists and objects to be flattened
+    
+    Returns
+    -------
+    list
+        Flattened list containing all objects found in aList
+    '''
+    rt = []
+    for item in aList:
+        if not isinstance(item, list):
+            rt.append(item)
         else:
-            f.extend(flatten(obj))
-    return f
+            rt.extend(flatten(item))
+    return rt
 
 
 def rebuild_macros(objs, i=0):

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -29,7 +29,7 @@ def flatten_list(aList):
         if not isinstance(item, list):
             rt.append(item)
         else:
-            rt.extend(flatten(item))
+            rt.extend(flatten_list(item))
     return rt
 
 
@@ -94,7 +94,8 @@ def force_partial_parse(parser, string, stats=False):
                 parsed += partialParse
         
         # print("Parsed: {:.2%}".format(1-(skips/olen)))
-        parsed = rebuild_macros(parsed)[0]
+        flattened = flatten_list(parsed)
+        parsed = rebuild_macros(flattened)[0]
         if type(parsed) == list:
             ret = [p for p in parsed if p != '\n']
         else:
@@ -383,8 +384,8 @@ class procedure:
     type = attr.ib(default='sql')
 
     def __attrs_post_init__(self):
-        self.outputs=flatten([self.outputs])
-        self.inputs=flatten([self.inputs])
+        self.outputs=flatten_list([self.outputs])
+        self.inputs=flatten_list([self.inputs])
 
 
 @attr.s 

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -733,7 +733,7 @@ mcroStart = ps.seq(
 mcroEnd = (ps.regex(r'%mend.*?;',flags=re.IGNORECASE)).map(macroEnd)
 
 # fullprogram: multiple SAS objects including macros
-fullprogram =  (nl|mcvDef|cmnt|datastep|proc|lbnm|icld|mcroStart|mcroEnd).many()
+fullprogram =  (nl|mcvDef|cmnt|datastep|proc|sql|lbnm|icld|mcroStart|mcroEnd).many()
 
 
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -100,6 +100,21 @@ testcases = [
 def test_include_parse(case, expected):
     assert cmnt.parse(case) == expected
 
+testcases = [
+    ('create table a as select * from b;',procedure(outputs=dataObject(library=None, dataset=['a'], options=None), inputs=[dataObject(library=None, dataset=['b'], options=None)]))
+]
+@pytest.mark.parametrize("case,expected", testcases)
+def test_create_table_parse(case, expected):
+    assert crtetbl.parse(case) == expected
+
+testcases = [
+    ('proc sql; create table a as select * from b left join select * from c on a.a=c.a right join select * from d on a.d=d.d; quit;',procedure(outputs=dataObject(library=None, dataset=['a'], options=None), inputs=[dataObject(library=None, dataset=['b'], options=None),dataObject(library=None, dataset=['c'], options=None),dataObject(library=None, dataset=['d'], options=None)]))
+]
+@pytest.mark.parametrize("case,expected", testcases)
+def test_sql_parse(case, expected):
+    assert sql.parse(case) == [expected]
+
+
 
 testcases = [
     ('%let a = 1;', macroVariableDefinition(variable=['a'],value=' 1')),

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -108,11 +108,12 @@ def test_create_table_parse(case, expected):
     assert crtetbl.parse(case) == expected
 
 testcases = [
-    ('proc sql; create table a as select * from b left join select * from c on a.a=c.a right join select * from d on a.d=d.d; quit;',procedure(outputs=dataObject(library=None, dataset=['a'], options=None), inputs=[dataObject(library=None, dataset=['b'], options=None),dataObject(library=None, dataset=['c'], options=None),dataObject(library=None, dataset=['d'], options=None)]))
+    ('proc sql; create table a as select * from b left join select * from c on a.a=c.a right join select * from d on a.d=d.d; quit;',[procedure(outputs=dataObject(library=None, dataset=['a'], options=None), inputs=[dataObject(library=None, dataset=['b'], options=None),dataObject(library=None, dataset=['c'], options=None),dataObject(library=None, dataset=['d'], options=None)])]),
+    ('proc sql; create table a as select * from b; select * from d; create table c as select * from d; quit;',[procedure(outputs=[dataObject(library=None, dataset=['a'], options=None)], inputs=[dataObject(library=None, dataset=['b'], options=None)]), unparsedSQLStatement(text='select * from d;'), procedure(outputs=[dataObject(library=None, dataset=['c'], options=None)], inputs=[dataObject(library=None, dataset=['d'], options=None)])])
 ]
 @pytest.mark.parametrize("case,expected", testcases)
 def test_sql_parse(case, expected):
-    assert sql.parse(case) == [expected]
+    assert sql.parse(case) == expected
 
 
 


### PR DESCRIPTION
# About 

Adds basic PROC SQL parsing for `create table` statement only. Collects any `join` statements. Also introduces `flatten_list` function to flatten nested lists into a single list. 

## To do
* Parse other common SQL statements (including `select x into :mvar` for macro variable creation) 
* Preven parser from failing on mixed PROC SQL where parser cannot recognise other statements. 