### PR TITLE
Line Information

### DIFF
--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -63,7 +63,7 @@ def rebuild_macros(objs, i=0):
     return output, i
 
 
-def force_partial_parse(parser, string, stats=False):
+def force_partial_parse(parser, string, stats=False, mark=False):
     """Force partial parse of string skipping unparsable characters
     
     Parameters
@@ -79,18 +79,36 @@ def force_partial_parse(parser, string, stats=False):
     -------
     list
         parsed objects from string"""
+    if mark:
+        parser = parser.mark()
     if isinstance(string, str):
         parsed = []
         olen = len(string)
         skips = 0
+        lastPosistion = (1, 0)
         while len(string) > 0:
             partialParse, string = parser.parse_partial(string)
-            if len(partialParse) == 0:
+            if mark:
+                start, obj, end = partialParse
+                start = [sum(x) for x in zip(start, lastPosistion)]
+                if end[0] == 0:
+                    lastPosistion = [sum(x) for x in zip(end, lastPosistion)]
+                else:
+                    lastPosistion = [end[0]+lastPosistion[0], end[1]]
+            else:
+                obj = partialParse
+
+            if obj is None:
                 string = string[1:]
                 skips += 1
+                lastPosistion = [lastPosistion[0], lastPosistion[1]+1]
             else:
-                parsed += partialParse
-        
+                if mark and not isinstance(obj,str):
+                    obj.set_found_posistion(start,lastPosistion)
+                
+                parsed.append(obj)
+                lastPosistion = [lastPosistion[0], lastPosistion[1]+1]
+
         # print("Parsed: {:.2%}".format(1-(skips/olen)))
         flattened = flatten_list(parsed)
         parsed = rebuild_macros(flattened)[0]
@@ -118,7 +136,15 @@ def force_partial_parse(parser, string, stats=False):
 #     - include
 
 @attr.s
-class macroVariable:
+class baseSASObject:
+
+    def set_found_posistion(self, start, end):
+        self.start = start
+        self.end = end
+
+
+@attr.s
+class macroVariable(baseSASObject):
     """
     Abstracted python class to reference the SAS macro variable.
 
@@ -133,7 +159,7 @@ class macroVariable:
     variable = attr.ib()
 
 @attr.s
-class comment:
+class comment(baseSASObject):
     """
     Abstracted python class to reference the SAS comment.
 
@@ -154,7 +180,7 @@ class comment:
     text = attr.ib()
 
 @attr.s
-class macroVariableDefinition:
+class macroVariableDefinition(baseSASObject):
     """
     Abstracted python class for the definition and assignment of macro varaibles.
     
@@ -186,7 +212,7 @@ class macroVariableDefinition:
     value = attr.ib()
 
 @attr.s 
-class include:
+class include(baseSASObject):
     """
     Abstracted python class for %include statements in SAS code.
 
@@ -229,7 +255,7 @@ class include:
 
 
 @attr.s
-class dataArg:
+class dataArg(baseSASObject):
     """
     Abstracted python class for an argument applied to a dataset in SAS.
 
@@ -257,7 +283,7 @@ class dataArg:
 
 
 @attr.s(repr=False)
-class dataObject:
+class dataObject(baseSASObject):
     """
     Abstracted python class for data objects created and used by SAS datasteps and procedures.
 
@@ -318,7 +344,7 @@ class dataObject:
         return self.name
 
 @attr.s
-class dataStep:
+class dataStep(baseSASObject):
     """
     Abstracted python class for parsing datasteps
     
@@ -353,7 +379,7 @@ class dataStep:
     body = attr.ib(repr=False, default=None)
 
 @attr.s
-class procedure:
+class procedure(baseSASObject):
     """
     Abstracted python class for parsing procedures.
 
@@ -386,7 +412,7 @@ class procedure:
         self.inputs=flatten_list([self.inputs])
 
 @attr.s
-class unparsedSQLStatement:
+class unparsedSQLStatement(baseSASObject):
     """
     Abstracted class for unparsed SQL statements found in
     proc sql procedures. Only currently parsed statement is
@@ -402,7 +428,7 @@ class unparsedSQLStatement:
     text = attr.ib()
 
 @attr.s 
-class libname:
+class libname(baseSASObject):
     """
     Abstracted python class for libname statements.
 
@@ -456,7 +482,7 @@ class libname:
             log.error("Unable to resolve path: {}".format(e))
 
 @attr.s
-class macroStart:
+class macroStart(baseSASObject):
     """
     Flagging class for start of %macro definition
 
@@ -471,7 +497,7 @@ class macroStart:
     arguments = attr.ib()
 
 @attr.s
-class macroEnd:
+class macroEnd(baseSASObject):
     """
     Flagging class for end of %macro definition
 
@@ -484,7 +510,7 @@ class macroEnd:
 
 
 @attr.s
-class macroargument:
+class macroargument(baseSASObject):
     """
     Abstracted python class for parsing a macro argument defintion.
 
@@ -517,7 +543,7 @@ class macroargument:
     doc = attr.ib()
 
 @attr.s
-class macro:
+class macro(baseSASObject):
     """
     Abstracted python class for SAS macro.
     
@@ -750,7 +776,5 @@ mcroStart = ps.seq(
 mcroEnd = (ps.regex(r'%mend.*?;',flags=re.IGNORECASE)).map(macroEnd)
 
 # fullprogram: multiple SAS objects including macros
-fullprogram =  (nl|mcvDef|cmnt|datastep|proc|sql|lbnm|icld|mcroStart|mcroEnd).many()
-
-
+fullprogram =  (nl|mcvDef|cmnt|datastep|proc|sql|lbnm|icld|mcroStart|mcroEnd).optional()
 

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -137,8 +137,25 @@ def force_partial_parse(parser, string, stats=False, mark=False):
 
 @attr.s
 class baseSASObject:
+    """
+    Base object containing general functions used by all SAS objects
+    """
 
     def set_found_posistion(self, start, end):
+        """
+        set_found_posistion(start, end)
+
+        Set the start and end attributes for the object. Used during 
+        force_partial_parse with mark=True to grab where in the SAS
+        program the object appears. 
+
+        Parameters
+        ----------
+        start : tuple 
+            The start line:char tuple for the object 
+        end : tuple 
+            The end line:char tuple for the objet 
+        """
         self.start = start
         self.end = end
 

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -107,7 +107,7 @@ def force_partial_parse(parser, string, stats=False, mark=False):
                     obj.set_found_posistion(start,lastPosistion)
                 
                 parsed.append(obj)
-                lastPosistion = [lastPosistion[0], lastPosistion[1]+1]
+                
 
         # print("Parsed: {:.2%}".format(1-(skips/olen)))
         flattened = flatten_list(parsed)

--- a/sasdocs/program.py
+++ b/sasdocs/program.py
@@ -64,7 +64,7 @@ class sasProgram(object):
             return False
 
         try:
-            self.contents, self.parsedRate = force_partial_parse(fullprogram, self.raw, stats=True)
+            self.contents, self.parsedRate = force_partial_parse(fullprogram, self.raw, stats=True, mark=True)
         except Exception as e:
             log.error("Unable to parse file: {}".format(e))
             return False

--- a/tests/samples/simple_1.sas
+++ b/tests/samples/simple_1.sas
@@ -1,7 +1,7 @@
 %include "a/bad/path";
 
 data test1;
-    set work.test;
+    set test;
 run;
 
 proc sort data=test1 out=test2; run;

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,18 +1,34 @@
 import pytest
 import pprint
-from sasdocs.objects import fullprogram, force_partial_parse, rebuild_macros
+from sasdocs.objects import *
 from sasdocs.program import sasProgram
 
 
 testcases = [
-    ('./tests/samples/simple_1.sas',None),
-    ('./tests/samples/macro_1.sas',None),
-    ('./tests/samples/macro_2.sas',None)
+    ('./tests/samples/simple_1.sas',[include(path='a/bad/path'),dataStep(outputs=[dataObject(library=None,dataset=['test1'],options=None)], inputs=[dataObject(library=None,dataset=['test'],options=None)], header='\n    ', body='\n'),procedure(type='sort',outputs=[dataObject(library=None,dataset=['test2'],options=None)],inputs=[dataObject(library=None,dataset=['test1'],options=None)])]),
+    # ('./tests/samples/macro_1.sas',None),
+    # ('./tests/samples/macro_2.sas',None)
 ]
 
 @pytest.mark.parametrize("case,expected", testcases)
 def test_simple_program(case, expected):
     res = sasProgram(case)
+    assert res.contents == expected
+
+testcases = [
+    ('./tests/samples/simple_1.sas',[([1,0],[1,22]),([3,0],[5,4]),([7,0],[7,36])]),
+    # ('./tests/samples/macro_1.sas',None),
+    # ('./tests/samples/macro_2.sas',None)
+]
+
+@pytest.mark.parametrize("case,expected", testcases)
+def test_get_posistion_program(case, expected):
+    res = sasProgram(case)
+    for obj, (start, end) in zip(res.contents,expected):
+        assert obj.start == start
+        assert obj.end == end
+
+
 
 
 test = sasProgram(testcases[0][0])

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -13,3 +13,8 @@ testcases = [
 @pytest.mark.parametrize("case,expected", testcases)
 def test_simple_program(case, expected):
     res = sasProgram(case)
+
+
+test = sasProgram(testcases[0][0])
+for obj in test.get_objects():
+    print(obj, obj.start, obj.end)


### PR DESCRIPTION
# Line Information
* Adds `set_found_position` and add a SASBaseObject class to store function in. 
* Edit `force_partial_parse` to allow for keyword `mark` argument. `mark=True` adds line and character start and stop attributes to parsed items

Rough implementation, has ruined any chance of `force_partial_parse` being cuspy. 

Also changes `fullprogram` parser to `.optional()` rather than `.many()`. `.many()` line info only returns line info for the entire parsed section, rather than the individual sections. **Potential issue further down the line.** 

Point continuity between parsed and un-parsable attempted but not thoroughly tested. 
