### PR TITLE
Add special characters to word

### DIFF
--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -518,7 +518,7 @@ reFlags = re.IGNORECASE|re.DOTALL
 # regex objects
 
 # Word: 1 or more alphanumeric characters
-wrd = ps.regex(r'[a-zA-Z0-9_\-!\.£$%^@#~|]+')
+wrd = ps.regex(r'[a-zA-Z0-9_\-]+')
 # FilePath: String terminating in a quote (used only for include and libname)
 fpth = ps.regex(r'[^\'"]+')
 
@@ -533,14 +533,13 @@ opdot = ps.string('.').optional().map(lambda x: '' if x is None else x)
 # Common identifiers
 nl = ps.string('\n')
 eq = ps.string('=')
-col = ps.string(';')
+col = ps.string(';') 
 amp = ps.string('&')
 lb = ps.string('(')
 rb = ps.string(')')
 star = ps.string('*')
 cmm = ps.string(',')
 
-anycharacter = ps.regex(r'.', flags=reFlags)
 
 # Multiline comment entry and exit points
 comstart = ps.string(r'/*')
@@ -657,14 +656,11 @@ program = (nl|mcvDef|cmnt|datastep|proc|lbnm|icld).many()
 
 mcroarg = ps.seq(
     arg = sasName << opspc,
-    default = (eq + opspc >> sasName).optional(),
+    default = (eq + opspc >> ps.regex(r'[a-zA-Z0-9_\-@\.\:]+').optional()).optional(),
     doc = cmnt.optional()
 ).combine_dict(macroargument)
 
 mcroargline = lb + opspc >> mcroarg.sep_by(opspc+cmm+opspc) << opspc + rb
-
-
-
 
 mcroStart = ps.seq(
     name = ps.regex(r'%macro',flags=re.IGNORECASE) + spc + opspc >> sasName,

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -518,7 +518,7 @@ reFlags = re.IGNORECASE|re.DOTALL
 # regex objects
 
 # Word: 1 or more alphanumeric characters
-wrd = ps.regex(r'[a-zA-Z0-9_-]+')
+wrd = ps.regex(r'[a-zA-Z0-9_\-!\.£$%^@#~|]+')
 # FilePath: String terminating in a quote (used only for include and libname)
 fpth = ps.regex(r'[^\'"]+')
 

--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -656,7 +656,7 @@ program = (nl|mcvDef|cmnt|datastep|proc|lbnm|icld).many()
 
 mcroarg = ps.seq(
     arg = sasName << opspc,
-    default = (eq + opspc >> ps.regex(r'[a-zA-Z0-9_\-@\.\:]+').optional()).optional(),
+    default = (eq + opspc >> ps.regex(r'(?:[a-zA-Z0-9_\-@\.\:]|\/(?!\*)|\\(?!\*))+').optional()).optional(),
     doc = cmnt.optional()
 ).combine_dict(macroargument)
 

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -114,15 +114,15 @@ def test_macroVariableDefinition_parse(case, expected):
 
 testcases = [
     ('a', macroargument(arg=['a'],default=None,doc=None)),
-    ('a=1', macroargument(arg=['a'],default=['1'],doc=None)),
-    ('a =1', macroargument(arg=['a'],default=['1'],doc=None)),
-    ('a = ', macroargument(arg=['a'],default=[],doc=None)),
-    ('a = 1', macroargument(arg=['a'],default=['1'],doc=None)),
+    ('a=1', macroargument(arg=['a'],default='1',doc=None)),
+    ('a =1', macroargument(arg=['a'],default='1',doc=None)),
+    ('a = ', macroargument(arg=['a'],default=None,doc=None)),
+    ('a = 1', macroargument(arg=['a'],default='1',doc=None)),
     ('a/*Docs*/', macroargument(arg=['a'],default=None,doc=comment(text="Docs"))),
-    ('a=1/*Docs*/', macroargument(arg=['a'],default=['1'],doc=comment(text="Docs"))),
-    ('a =1/*Docs*/', macroargument(arg=['a'],default=['1'],doc=comment(text="Docs"))),
-    ('a = /*Docs*/', macroargument(arg=['a'],default=[],doc=comment(text="Docs"))),
-    ('a = 1/*Docs*/', macroargument(arg=['a'],default=['1'],doc=comment(text="Docs"))),
+    ('a=1/*Docs*/', macroargument(arg=['a'],default='1',doc=comment(text="Docs"))),
+    ('a =1/*Docs*/', macroargument(arg=['a'],default='1',doc=comment(text="Docs"))),
+    ('a = /*Docs*/', macroargument(arg=['a'],default=None,doc=comment(text="Docs"))),
+    ('a = 1/*Docs*/', macroargument(arg=['a'],default='1',doc=comment(text="Docs"))),
 ]
 @pytest.mark.parametrize("case,expected", testcases)
 def test_macroargument_parse(case, expected):
@@ -131,10 +131,10 @@ def test_macroargument_parse(case, expected):
 
 testcases = [
     ('(a, b, c)', [macroargument(arg=['a'],default=None,doc=None), macroargument(arg=['b'],default=None,doc=None), macroargument(arg=['c'],default=None,doc=None)]),
-    ('(a=1, b)', [macroargument(arg=['a'],default=['1'],doc=None), macroargument(arg=['b'],default=None,doc=None)]),
-    ('(a=1, b=2)', [macroargument(arg=['a'],default=['1'],doc=None), macroargument(arg=['b'],default=['2'],doc=None)]),
-    ('(a=1/*Doc A*/,b=2)', [macroargument(arg=['a'],default=['1'],doc=comment(text="Doc A")), macroargument(arg=['b'],default=['2'],doc=None)]),
-    ('(a=1/*Doc A*/,b/*Doc B*/)', [macroargument(arg=['a'],default=['1'],doc=comment(text="Doc A")), macroargument(arg=['b'],default=None,doc=comment(text="Doc B"))]),
+    ('(a=1, b)', [macroargument(arg=['a'],default='1',doc=None), macroargument(arg=['b'],default=None,doc=None)]),
+    ('(a=1, b=2)', [macroargument(arg=['a'],default='1',doc=None), macroargument(arg=['b'],default='2',doc=None)]),
+    ('(a=1/*Doc A*/,b=2)', [macroargument(arg=['a'],default='1',doc=comment(text="Doc A")), macroargument(arg=['b'],default='2',doc=None)]),
+    ('(a=1/*Doc A*/,b/*Doc B*/)', [macroargument(arg=['a'],default='1',doc=comment(text="Doc A")), macroargument(arg=['b'],default=None,doc=comment(text="Doc B"))]),
 ]
 @pytest.mark.parametrize("case,expected", testcases)
 def test_macroargumentLine_parse(case, expected):
@@ -143,9 +143,9 @@ def test_macroargumentLine_parse(case, expected):
 testcases = [
     ('%macro test; %mend;', macro(name=['test'], arguments=None, contents='')),
     ('%macro test(a, b, c); %mend;', macro(name=['test'], arguments=[macroargument(arg=['a'],default=None,doc=None), macroargument(arg=['b'],default=None,doc=None), macroargument(arg=['c'],default=None,doc=None)], contents='')),
-    ('%macro test (a=1/*Doc A*/,b/*Doc B*/); %mend;', macro(name=['test'], arguments=[macroargument(arg=['a'],default=['1'],doc=comment(text="Doc A")), macroargument(arg=['b'],default=None,doc=comment(text="Doc B"))], contents='')),
+    ('%macro test (a=1/*Doc A*/,b/*Doc B*/); %mend;', macro(name=['test'], arguments=[macroargument(arg=['a'],default='1',doc=comment(text="Doc A")), macroargument(arg=['b'],default=None,doc=comment(text="Doc B"))], contents='')),
     ('%macro test; data a; set b; run; %mend;', macro(name=['test'], arguments=None, contents=[dataStep(outputs=[dataObject(library=None, dataset=['a'], options=None)], header=' ', inputs=[dataObject(library=None, dataset=['b'], options=None)], body=' ')])),                                                                    
-    ('%macro test(a=1/*Doc A*/,b/*Doc B*/); data a; set b; run; %mend;', macro(name=['test'], arguments=[macroargument(arg=['a'], default=['1'], doc=comment(text='Doc A')), macroargument(arg=['b'], default=None, doc=comment(text='Doc B'))], contents=[dataStep(outputs=[dataObject(library=None, dataset=['a'], options=None)], header=' ', inputs=[dataObject(library=None, dataset=['b'], options=None)], body=' ')])),
+    ('%macro test(a=1/*Doc A*/,b/*Doc B*/); data a; set b; run; %mend;', macro(name=['test'], arguments=[macroargument(arg=['a'], default='1', doc=comment(text='Doc A')), macroargument(arg=['b'], default=None, doc=comment(text='Doc B'))], contents=[dataStep(outputs=[dataObject(library=None, dataset=['a'], options=None)], header=' ', inputs=[dataObject(library=None, dataset=['b'], options=None)], body=' ')])),
 ]
 
 @pytest.mark.parametrize("case,expected", testcases)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -123,6 +123,9 @@ testcases = [
     ('a =1/*Docs*/', macroargument(arg=['a'],default='1',doc=comment(text="Docs"))),
     ('a = /*Docs*/', macroargument(arg=['a'],default=None,doc=comment(text="Docs"))),
     ('a = 1/*Docs*/', macroargument(arg=['a'],default='1',doc=comment(text="Docs"))),
+    ('a = a.b@c.com/*Email*/', macroargument(arg=['a'],default='a.b@c.com',doc=comment(text="Email"))),
+    ('a = //path/to/file/*Fpath*/', macroargument(arg=['a'],default='//path/to/file',doc=comment(text="Fpath"))),
+    ('a = C:/path/to/file/*Fpath*/', macroargument(arg=['a'],default='C:/path/to/file',doc=comment(text="Fpath"))),
 ]
 @pytest.mark.parametrize("case,expected", testcases)
 def test_macroargument_parse(case, expected):


### PR DESCRIPTION
Add special characters to `wrd` parser to prevent failure on email addresses ect. 