### PR TITLE
Handle malformed macro better, fixes  #19

### DIFF
--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -28,7 +28,7 @@ def rebuild_macros(objs, i=0):
     output = []
     while i < len(objs):
         obj = objs[i]
-        if type(obj) == macroEnd:
+        if len(output) > 0 and type(output[0]) == macroStart and type(obj) == macroEnd:
             return (macro(name=output[0].name, arguments=output[0].arguments, contents=output[1:]), i)
         elif type(obj) != macroStart or (type(obj) == macroStart and len(output)==0) :
             output.append(obj)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -237,3 +237,39 @@ def test_force_partial_marco_parse(case, expected):
     assert res == expected
 
 
+testcases = [("""
+libname a "path/to/folder";
+%let a = 1;
+data a.data2;
+    set a.data1;
+run;
+
+*inline comment;
+*inline comment;
+/*Comment*/
+proc summary data=a.data2 nway; 
+    class a b c;
+    output out=a.data3;
+run;
+%mend;
+proc transpose data=a.data3 out=a.data4;
+    by a;
+run;
+""",
+[
+libname(library=['a'], path='path/to/folder', pointer=None),
+macroVariableDefinition(variable=['a'], value=' 1'),
+dataStep(outputs=[dataObject(library=['a'], dataset=['data2'], options=None)], header='\n    ', inputs=[dataObject(library=['a'], dataset=['data1'], options=None)], body='\n'),
+comment(text='inline comment'),
+comment(text='inline comment'),
+comment(text='Comment'),
+procedure(outputs=dataObject(library=['a'], dataset=['data3'], options=None), inputs=dataObject(library=['a'], dataset=['data2'], options=None), type='summary'),
+macroEnd(text='%mend;'),
+procedure(outputs=dataObject(library=['a'], dataset=['data4'], options=None), inputs=dataObject(library=['a'], dataset=['data3'], options=None), type='transpose')
+])]
+
+
+@pytest.mark.parametrize("case,expected", testcases)
+def test_force_partial_incomplete_marco_parse(case, expected):
+    res = force_partial_parse(fullprogram, case)
+    assert res == expected


### PR DESCRIPTION
Handles malformed macro's better in `rebuild_macros`. Only attempts to rebuild the macro if there exists a macro and corresponding `%mend` statement. 