### PR TITLE
datastep header can't read past run

### DIFF
--- a/sasdocs/objects.py
+++ b/sasdocs/objects.py
@@ -88,6 +88,7 @@ def force_partial_parse(parser, string, stats=False, mark=False):
         lastPosistion = (1, 0)
 
         while len(string) > 0:
+            
             partialParse, string = parser.parse_partial(string)
             
             if mark:
@@ -739,7 +740,7 @@ dataLine = dataObj.sep_by(spc)
 
 datastep = ps.seq(
     outputs = (ps.regex(r'data', flags=re.IGNORECASE) + spc) >> dataLine << col,
-    header = (ps.regex(r'.*?(?=set|merge)', flags=reFlags)).optional(),
+    header = (ps.regex(r'(?:(?!run).)*(?=set|merge)', flags=reFlags)).optional(),
     inputs = ((opspc + ps.regex(r'set|merge',flags=re.IGNORECASE) + opspc) >> dataLine << col).optional(),
     body = ps.regex(r'.*?(?=run)', flags=reFlags),
     _run = run + opspc + col


### PR DESCRIPTION
Setting header to optional was allowing for the datastep header to read past the end of the datastep and in some cases grab the entire program into the header. 